### PR TITLE
Update Linux dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ After you start the script you just press **F2** to start/stop recording. After 
 
 **Step 1 (Linux - Ubuntu,Debian):**
 
-    sudo apt-get install python3 python3-pip git ffmpeg
+    sudo apt-get install python3 python3-pip git ffmpeg python3-pyaudio portaudio19-dev
 
 **Step 1 (Windows):**
 


### PR DESCRIPTION
On Debian 12 (and probably other distributions), you have to install the added packages on STEP 1 to avoid getting an error while Building wheel for pyaudio (9 | #include "portaudio.h" not found) during STEP 2.